### PR TITLE
feat(ninja): add datadog-ninja with 11 official Datadog skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,26 @@ The Azure Ninja orchestrates Azure expertise across the full deployment lifecycl
 
 ---
 
+### <img src="https://img.shields.io/badge/Datadog-632CA6?style=flat&logo=datadog&logoColor=white" height="20"/> Datadog Ninja
+
+> **11 skills** from the official `DataDog/pup` repository
+
+The Datadog Ninja routes observability work to the right Datadog specialist:
+
+| Category | Skills | Examples |
+|----------|--------|----------|
+| **CLI & Foundation** | 4 | `pup` OAuth2 auth, docs lookup, API client code generation |
+| **APM & Tracing** | 1 | Traces, services, dependencies, latency analysis |
+| **Logs** | 1 | Log search, pipelines, archives, cost control |
+| **Monitors** | 1 | Alert creation, updates, muting |
+| **Live Debugging** | 2 | Runtime log probes, symbol database lookup |
+| **CI & Test Optimization** | 2 | Unblock failing PRs, triage flaky tests |
+
+**Source repository:**
+- [DataDog/pup](https://github.com/DataDog/pup) — Official Datadog CLI and bundled agent skills
+
+---
+
 ### <img src="https://img.shields.io/badge/Firecrawl-FF6B35?style=flat&logo=firebase&logoColor=white" height="20"/> Firecrawl Ninja
 
 > **33 skills** for web scraping, research, and data extraction
@@ -192,33 +212,6 @@ The Firecrawl Ninja is your specialist for web data operations:
 
 **Source repository:**
 - [firecrawl/skills](https://github.com/firecrawl/skills)
-
----
-
-### <img src="https://img.shields.io/badge/Datadog-632CA6?style=flat&logo=datadog&logoColor=white" height="20"/> Datadog Ninja
-
-> **20+ skills** from the official `DataDog/pup` repository + community collection
-
-The Datadog Ninja routes observability and incident work to the right Datadog specialist:
-
-| Category | Skills | Examples |
-|----------|--------|----------|
-| **CLI & Foundation** | 4 | `pup` auth, docs lookup, API client code generation |
-| **APM & Tracing** | 2 | Traces, service maps, latency analysis, profiling |
-| **Logs** | 2 | Log search, pipelines, archives, cost control |
-| **Metrics & SLOs** | 1 | Custom metrics, SLIs, performance baselines |
-| **Monitors** | 2 | Alert creation, muting, notification routing |
-| **Incidents** | 1 | Declare, coordinate, postmortem |
-| **CI Visibility** | 3 | Unblock PRs, triage flaky tests, quality gates |
-| **Live Debugging** | 2 | Runtime probes, symbol database |
-| **Synthetics** | 1 | API tests, browser tests, uptime checks |
-| **Security** | 1 | Cloud SIEM signals, CSPM, vulnerability triage |
-| **AI Observability** | 1 | LLM tracing, token usage, evaluations |
-| **Sales Engineering** | 3 | Demo scenarios, SE demos, competitive battlecards |
-
-**Source repositories:**
-- [DataDog/pup](https://github.com/DataDog/pup) — Official Datadog CLI + skills
-- [Kirneill/DataDogAdditions](https://github.com/Kirneill/DataDogAdditions) — Community Datadog skills
 
 ---
 
@@ -347,8 +340,8 @@ jump-skills/
 ├── ninjas/                           # Ninja definitions
 │   ├── aws-ninja/SKILL.md            # AWS orchestrator (230+ skills)
 │   ├── azure-ninja/SKILL.md          # Azure orchestrator (40 skills)
+│   ├── datadog-ninja/SKILL.md        # Datadog orchestrator (11 skills)
 │   ├── firecrawl-ninja/SKILL.md      # Firecrawl orchestrator (33 skills)
-│   ├── datadog-ninja/SKILL.md        # Datadog orchestrator (20+ skills)
 │   ├── google-cloud-ninja/SKILL.md   # Google Cloud orchestrator (85+ skills)
 │   ├── google-ai-ninja/SKILL.md      # Google AI orchestrator (25+ skills)
 │   ├── google-ads-ninja/SKILL.md     # Google Ads orchestrator (15+ skills)
@@ -364,8 +357,8 @@ jump-skills/
 ├── repos/                     # 📁 Cloned source repositories (git-ignored)
 │   ├── aws-ninja/             #    └── 10 AWS repos
 │   ├── azure-ninja/           #    └── 2 Azure repos
+│   ├── datadog-ninja/         #    └── 1 Datadog repo
 │   ├── firecrawl-ninja/       #    └── 1 Firecrawl repo
-│   ├── datadog-ninja/         #    └── 2 Datadog repos
 │   ├── google-cloud-ninja/    #    └── 1 Google repo
 │   ├── google-ai-ninja/       #    └── 2 Google repos
 │   ├── google-ads-ninja/      #    └── 1 Google repo

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Multi-Tenant Ninja System for AI Agent Orchestration
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](LICENSE)
-[![Ninjas](https://img.shields.io/badge/Ninjas-9-blueviolet?style=for-the-badge&logo=github)](#-available-ninjas)
+[![Ninjas](https://img.shields.io/badge/Ninjas-10-blueviolet?style=for-the-badge&logo=github)](#-available-ninjas)
 [![Skills](https://img.shields.io/badge/Skills-500+-green?style=for-the-badge&logo=github)](#-available-ninjas)
 
 <br/>
@@ -195,6 +195,33 @@ The Firecrawl Ninja is your specialist for web data operations:
 
 ---
 
+### <img src="https://img.shields.io/badge/Datadog-632CA6?style=flat&logo=datadog&logoColor=white" height="20"/> Datadog Ninja
+
+> **20+ skills** from the official `DataDog/pup` repository + community collection
+
+The Datadog Ninja routes observability and incident work to the right Datadog specialist:
+
+| Category | Skills | Examples |
+|----------|--------|----------|
+| **CLI & Foundation** | 4 | `pup` auth, docs lookup, API client code generation |
+| **APM & Tracing** | 2 | Traces, service maps, latency analysis, profiling |
+| **Logs** | 2 | Log search, pipelines, archives, cost control |
+| **Metrics & SLOs** | 1 | Custom metrics, SLIs, performance baselines |
+| **Monitors** | 2 | Alert creation, muting, notification routing |
+| **Incidents** | 1 | Declare, coordinate, postmortem |
+| **CI Visibility** | 3 | Unblock PRs, triage flaky tests, quality gates |
+| **Live Debugging** | 2 | Runtime probes, symbol database |
+| **Synthetics** | 1 | API tests, browser tests, uptime checks |
+| **Security** | 1 | Cloud SIEM signals, CSPM, vulnerability triage |
+| **AI Observability** | 1 | LLM tracing, token usage, evaluations |
+| **Sales Engineering** | 3 | Demo scenarios, SE demos, competitive battlecards |
+
+**Source repositories:**
+- [DataDog/pup](https://github.com/DataDog/pup) — Official Datadog CLI + skills
+- [Kirneill/DataDogAdditions](https://github.com/Kirneill/DataDogAdditions) — Community Datadog skills
+
+---
+
 ### <img src="https://img.shields.io/badge/Google_Cloud-4285F4?style=flat&logo=googlecloud&logoColor=white" height="20"/> Google Cloud Ninja
 
 > **85+ skills** from official Google repositories
@@ -321,6 +348,7 @@ jump-skills/
 │   ├── aws-ninja/SKILL.md            # AWS orchestrator (230+ skills)
 │   ├── azure-ninja/SKILL.md          # Azure orchestrator (40 skills)
 │   ├── firecrawl-ninja/SKILL.md      # Firecrawl orchestrator (33 skills)
+│   ├── datadog-ninja/SKILL.md        # Datadog orchestrator (20+ skills)
 │   ├── google-cloud-ninja/SKILL.md   # Google Cloud orchestrator (85+ skills)
 │   ├── google-ai-ninja/SKILL.md      # Google AI orchestrator (25+ skills)
 │   ├── google-ads-ninja/SKILL.md     # Google Ads orchestrator (15+ skills)
@@ -337,6 +365,7 @@ jump-skills/
 │   ├── aws-ninja/             #    └── 10 AWS repos
 │   ├── azure-ninja/           #    └── 2 Azure repos
 │   ├── firecrawl-ninja/       #    └── 1 Firecrawl repo
+│   ├── datadog-ninja/         #    └── 2 Datadog repos
 │   ├── google-cloud-ninja/    #    └── 1 Google repo
 │   ├── google-ai-ninja/       #    └── 2 Google repos
 │   ├── google-ads-ninja/      #    └── 1 Google repo
@@ -536,6 +565,7 @@ Jump Skills is a **meta-repository** — it orchestrates skills from multiple ex
 - **[Firebase](https://github.com/firebase)** — For Firebase agent skills
 - **[GitHub](https://github.com/github)** — For the awesome-copilot community collection
 - **[Firecrawl](https://github.com/firecrawl)** — For web scraping skills
+- **[Datadog](https://github.com/DataDog)** — For the `pup` CLI and official Datadog skills
 - **[Agent Skills Specification](https://github.com/awslabs/agent-plugins)** — Standard skill format
 - **[skills.sh](https://skills.sh)** — Multi-agent installer inspiration
 - **[Shields.io](https://shields.io)** — Beautiful badges

--- a/ninjas.md
+++ b/ninjas.md
@@ -8,6 +8,7 @@ Lista de Jump Skills disponíveis. Cada ninja é um roteador inteligente que orq
 aws-ninja
 azure-ninja
 firecrawl-ninja
+datadog-ninja
 google-cloud-ninja
 google-ai-ninja
 google-ads-ninja
@@ -23,6 +24,7 @@ google-analytics-ninja
 | `aws-ninja` | Orquestra 230+ skills AWS oficiais (EKS, Lambda, DynamoDB, CDK, Security, etc.) | 230+ |
 | `azure-ninja` | Orquestra 40 skills Azure (AKS, App Service, Entra, Foundry, DevOps, Cost, etc.) | 40 |
 | `firecrawl-ninja` | Orquestra skills Firecrawl (scrape, search, crawl, workflows, etc.) | 33 |
+| `datadog-ninja` | Orquestra skills Datadog (APM, logs, monitors, incidents, synthetics, CI visibility, security) | 20+ |
 | `google-cloud-ninja` | Orquestra 85+ skills Google Cloud (GKE, Cloud Run, BigQuery, IAM, Storage, WAF) | 85+ |
 | `google-ai-ninja` | Orquestra 25+ skills Google AI (Gemini API, Agent Platform, Genkit, RAG) | 25+ |
 | `google-ads-ninja` | Orquestra 15+ skills Google Ads (Ads API, Mobile Ads SDK, IMA SDK) | 15+ |

--- a/ninjas.md
+++ b/ninjas.md
@@ -7,8 +7,8 @@ Lista de Jump Skills disponíveis. Cada ninja é um roteador inteligente que orq
 ```ninjas
 aws-ninja
 azure-ninja
-firecrawl-ninja
 datadog-ninja
+firecrawl-ninja
 google-cloud-ninja
 google-ai-ninja
 google-ads-ninja
@@ -23,8 +23,8 @@ google-analytics-ninja
 |-------|-----------|--------|
 | `aws-ninja` | Orquestra 230+ skills AWS oficiais (EKS, Lambda, DynamoDB, CDK, Security, etc.) | 230+ |
 | `azure-ninja` | Orquestra 40 skills Azure (AKS, App Service, Entra, Foundry, DevOps, Cost, etc.) | 40 |
+| `datadog-ninja` | Orquestra 11 skills Datadog oficiais (APM, logs, monitors, live debugger, CI/flaky tests) | 11 |
 | `firecrawl-ninja` | Orquestra skills Firecrawl (scrape, search, crawl, workflows, etc.) | 33 |
-| `datadog-ninja` | Orquestra skills Datadog (APM, logs, monitors, incidents, synthetics, CI visibility, security) | 20+ |
 | `google-cloud-ninja` | Orquestra 85+ skills Google Cloud (GKE, Cloud Run, BigQuery, IAM, Storage, WAF) | 85+ |
 | `google-ai-ninja` | Orquestra 25+ skills Google AI (Gemini API, Agent Platform, Genkit, RAG) | 25+ |
 | `google-ads-ninja` | Orquestra 15+ skills Google Ads (Ads API, Mobile Ads SDK, IMA SDK) | 15+ |

--- a/ninjas/datadog-ninja/SKILL.md
+++ b/ninjas/datadog-ninja/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: datadog-ninja
+description: >-
+  Master orchestrator for 20+ Datadog agent skills from the official DataDog/pup repository
+  and community Datadog skill collections. Use when working with ANY Datadog observability
+  task: APM and distributed tracing, log search and pipelines, metrics, monitors and alerting,
+  incidents, synthetics, CI visibility and flaky tests, live debugging, security signals, or
+  AI/LLM observability. Routes to the optimal specialized skill based on context.
+  Triggers: Datadog, DataDog, dd, pup CLI, APM, distributed tracing, traces, spans, service map,
+  flame graph, datadog logs, log pipelines, log archives, custom metrics, SLO, SLI, monitors,
+  alerting, mute, downtime, incident, postmortem, synthetics, browser test, CI Visibility,
+  flaky test, test optimization, live debugger, dynamic instrumentation, probes, symbol database,
+  Cloud SIEM, CSPM, security signals, LLM observability, dashboards, datadog-ci, DD_API_KEY.
+---
+
+# Datadog Ninja
+
+**Jump Skill** — Master orchestrator that routes Datadog observability tasks to specialized skills from the official `DataDog/pup` repository and community Datadog skill collections.
+
+## Purpose
+
+This skill acts as an intelligent router to the Datadog skills library. Instead of manually searching for the right skill, describe your observability task and this skill will:
+
+1. Identify the most relevant specialized skill(s)
+2. Load the full skill instructions on demand
+3. Execute the task with expert-level Datadog knowledge
+
+## Prerequisites
+
+Nearly every skill in this catalog drives the **`pup` CLI** (the official Datadog CLI). Before executing a task:
+
+1. Route to `dd-pup` if `pup` is not installed or not authenticated
+2. `pup` uses OAuth2 with token refresh — no long-lived key in the shell for interactive use
+3. Application-side code generation and CI tooling use `DD_API_KEY` / `DD_APP_KEY` instead
+4. Datadog site matters (`datadoghq.com`, `datadoghq.eu`, `us3`, `us5`, `ap1`) — confirm `DD_SITE` before API calls
+
+> Read operations (searching logs, querying metrics, listing monitors) are safe to run directly.
+> Write operations (creating/muting monitors, declaring incidents, deleting pipelines) change
+> production state — confirm intent with the user before executing them.
+
+## Skill Catalog
+
+### CLI & Foundation
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `dd-pup` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-pup/` | Install/authenticate the `pup` CLI, OAuth2 setup, token refresh, org and site selection |
+| `dd-docs` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-docs/` | Look up Datadog documentation via `docs.datadoghq.com/llms.txt` |
+| `dd-code-generation` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-code-generation/` | Generate application code using Datadog API clients (TypeScript, Python, Java, Go, Rust) instead of ad-hoc CLI calls |
+| `dd-file-issue` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-file-issue/` | File a bug or feature request against the `pup` CLI or its plugins |
+
+### APM & Tracing
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `dd-apm` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-apm/` | Traces, services, dependencies, performance analysis (official) |
+| `datadog-apm` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-apm/` | Service maps, latency percentiles, continuous profiler, deeper APM API workflows |
+
+**APM Capabilities:**
+- Search and inspect distributed traces and spans
+- Map service dependencies and detect topology changes
+- Latency analysis (p50/p95/p99), error rates, throughput
+- Identify slow endpoints and downstream bottlenecks
+- Continuous profiling for CPU and memory hotspots
+
+### Logs
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `dd-logs` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-logs/` | Log search, pipelines, archives, indexes, cost control (official) |
+| `datadog-logs` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-logs/` | Incident-time log investigation, error pattern analysis via `pup` |
+
+**Log Capabilities:**
+- Search logs with Datadog query syntax and facets
+- Build and debug processing pipelines (grok, remapper, category)
+- Configure indexes, exclusion filters, and retention for cost control
+- Set up and query log archives (S3/GCS/Azure) and rehydration
+
+### Metrics & SLOs
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `datadog-metrics` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-metrics/` | Query/submit metrics, custom metrics, SLIs, performance baselines, metric cardinality |
+
+### Monitors & Alerting
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `dd-monitors` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-monitors/` | Create/update/mute monitors, alerting best practices (official) |
+| `datadog-monitors` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-monitors/` | Notification routing, deploy-window muting, SLO-based alerts |
+
+### Incidents
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `datadog-incidents` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-incidents/` | Declare/manage/resolve incidents, timeline updates, responder coordination, postmortems |
+
+### CI Visibility & Test Optimization
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `dd-unblock-pr` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-unblock-pr/` | A PR's CI is failing — attribute each failure as flaky, infra, or regression; report coverage |
+| `dd-triage-flaky-test` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-triage-flaky-test/` | Investigating one specific flaky test — history, failure pattern, fix vs quarantine vs escalate |
+| `datadog-ci-visibility` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-ci-visibility/` | Upload test results, track deployments, quality gates, pipeline monitoring via `datadog-ci` |
+
+### Live Debugging
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `dd-debugger` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-debugger/` | Capture runtime argument/variable values in production with log probes — no redeploy |
+| `dd-symdb` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-symdb/` | Search a service's symbols to find probe-able methods before placing a probe |
+
+> `dd-symdb` almost always precedes `dd-debugger`: find the method, then probe it.
+
+### Synthetics
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `datadog-synthetics` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-synthetics/` | Synthetic API tests, browser tests, multi-step monitors via `datadog-ci` |
+
+### Security
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `datadog-security` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-security/` | Cloud SIEM security signals, CSPM findings, compliance posture, vulnerability triage |
+
+### AI / LLM Observability
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `datadog-ai-observability` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-ai-observability/` | Monitor LLM apps, trace agent chains, token usage, LLM evaluations |
+
+### Sales Engineering (non-technical)
+
+| Skill | Path | Use When |
+|-------|------|----------|
+| `datadog-demo` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-demo/` | Run a pre-built demo scenario of a Datadog investigation end-to-end |
+| `datadog-se-demo` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-se-demo/` | Structure an SE demo round or customer presentation |
+| `datadog-competitive` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-competitive/` | Datadog vs Splunk / New Relic / Dynatrace / Grafana / Elastic comparisons, battlecards |
+
+> These three are sales-oriented, not operational. Do not route engineering tasks to them.
+
+## Routing Logic
+
+When a task arrives:
+
+1. **`pup` not installed or auth failing?** → `dd-pup` first, then the real skill
+2. **Slow service, latency, traces, spans, service map?** → `dd-apm` (add `datadog-apm` for profiling)
+3. **Searching logs, log pipelines, log cost/retention?** → `dd-logs` (`datadog-logs` for incident-time search)
+4. **Metrics, custom metrics, SLIs, baselines?** → `datadog-metrics`
+5. **Creating/muting alerts, notification routing?** → `dd-monitors` (`datadog-monitors` for SLO alerts)
+6. **Production incident, postmortem, responders?** → `datadog-incidents`
+7. **PR CI red, unclear if flaky?** → `dd-unblock-pr`
+8. **One known flaky test?** → `dd-triage-flaky-test`
+9. **Uploading test results, quality gates, deploy tracking?** → `datadog-ci-visibility`
+10. **"What value does this variable have in prod?"** → `dd-symdb` then `dd-debugger`
+11. **Uptime checks, browser tests, API monitoring?** → `datadog-synthetics`
+12. **Security signals, CSPM, compliance, vulns?** → `datadog-security`
+13. **LLM/agent tracing, token spend, evals?** → `datadog-ai-observability`
+14. **Instrumenting an app in code, API client?** → `dd-code-generation`
+15. **Datadog docs question?** → `dd-docs`
+16. **Demo, presentation, competitor comparison?** → `datadog-demo` / `datadog-se-demo` / `datadog-competitive`
+
+## Execution Pattern
+
+```
+1. Announce: "Routing to [skill-name]..."
+2. Verify: pup installed + authenticated (route to dd-pup if not)
+3. Load: Read the SKILL.md from the path in the catalog
+4. Execute: Follow the skill's instructions
+5. Confirm: For any write operation, confirm with the user before running it
+6. Cite: Reference the skill in the response
+```
+
+## Quick Reference
+
+| Task | Route To |
+|------|----------|
+| Install / authenticate Datadog CLI | `dd-pup` |
+| Why is this endpoint slow? | `dd-apm` |
+| Profile CPU/memory in production | `datadog-apm` |
+| Search error logs for a service | `dd-logs` |
+| Cut log ingestion cost | `dd-logs` |
+| Build a log processing pipeline | `dd-logs` |
+| Query a custom metric | `datadog-metrics` |
+| Define an SLI / SLO | `datadog-metrics` |
+| Create an alert | `dd-monitors` |
+| Mute alerts during a deploy | `datadog-monitors` |
+| Declare an incident | `datadog-incidents` |
+| Write a postmortem | `datadog-incidents` |
+| My PR's CI is red | `dd-unblock-pr` |
+| Is this test flaky? | `dd-triage-flaky-test` |
+| Add quality gates to CI | `datadog-ci-visibility` |
+| What arguments does this function get in prod? | `dd-symdb` → `dd-debugger` |
+| Add an uptime / browser check | `datadog-synthetics` |
+| Triage a security signal | `datadog-security` |
+| Trace an LLM agent chain | `datadog-ai-observability` |
+| Instrument my app with the Datadog SDK | `dd-code-generation` |
+| How does feature X work in Datadog? | `dd-docs` |
+| Report a `pup` bug | `dd-file-issue` |
+
+## Investigation Decision Tree
+
+```
+Something is wrong in production
+
+Where does the symptom show up?
+├── Requests slow / erroring
+│   ├── Which service? → dd-apm (service map, trace search)
+│   ├── Which line of code? → dd-apm (flame graph) → dd-debugger (live values)
+│   └── Resource-bound? → datadog-apm (continuous profiler)
+├── Errors in the logs
+│   ├── Find them → dd-logs / datadog-logs
+│   └── Logs missing or malformed → dd-logs (pipelines, indexes)
+├── Host / infra symptom
+│   └── datadog-metrics (infra metrics, baselines)
+├── Alert fired (or should have)
+│   ├── Tune / create → dd-monitors
+│   └── Routing / muting → datadog-monitors
+├── Users report it before you do
+│   └── datadog-synthetics (uptime & browser checks)
+├── It's an incident
+│   └── datadog-incidents (declare, coordinate, postmortem)
+└── It's suspicious, not just broken
+    └── datadog-security (signals, CSPM findings)
+
+CI is broken (not production)
+├── Whole PR pipeline red → dd-unblock-pr
+├── One test flapping → dd-triage-flaky-test
+└── Coverage / gates / uploads → datadog-ci-visibility
+```
+
+## Common `pup` Commands
+
+```bash
+pup auth login                          # OAuth2 login
+pup auth status                         # Verify authentication and org
+pup logs search 'service:api status:error' --from now-1h
+pup metrics query 'avg:system.cpu.user{*}' --from now-4h
+pup monitors list --tags team:platform
+pup monitors mute <monitor_id> --end <ts>
+pup apm services list
+pup incidents list --state active
+```
+
+> Exact flags vary by `pup` version — route to `dd-pup` and confirm against `pup --help`
+> rather than assuming the syntax above.
+
+## Statistics
+
+- **Total Skills:** 20+ operational (23 including sales-engineering skills)
+- **Repositories:** `DataDog/pup` (official), `Kirneill/DataDogAdditions` (community)
+- **Source:** Official Datadog CLI skills + community Datadog skill collection
+
+---
+
+*Jump Skill maintained at github.com/fabricioctelles/jump-skills*

--- a/ninjas/datadog-ninja/SKILL.md
+++ b/ninjas/datadog-ninja/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: datadog-ninja
 description: >-
-  Master orchestrator for 20+ Datadog agent skills from the official DataDog/pup repository
-  and community Datadog skill collections. Use when working with ANY Datadog observability
-  task: APM and distributed tracing, log search and pipelines, metrics, monitors and alerting,
-  incidents, synthetics, CI visibility and flaky tests, live debugging, security signals, or
-  AI/LLM observability. Routes to the optimal specialized skill based on context.
+  Master orchestrator for 11 official Datadog agent skills from the DataDog/pup repository.
+  Use when working with ANY Datadog observability task: APM and distributed tracing, log
+  search and pipelines, monitors and alerting, live production debugging, symbol lookup,
+  CI test optimization and flaky tests, or generating Datadog API client code.
+  Routes to the optimal specialized skill based on context.
   Triggers: Datadog, DataDog, dd, pup CLI, APM, distributed tracing, traces, spans, service map,
-  flame graph, datadog logs, log pipelines, log archives, custom metrics, SLO, SLI, monitors,
-  alerting, mute, downtime, incident, postmortem, synthetics, browser test, CI Visibility,
-  flaky test, test optimization, live debugger, dynamic instrumentation, probes, symbol database,
-  Cloud SIEM, CSPM, security signals, LLM observability, dashboards, datadog-ci, DD_API_KEY.
+  flame graph, datadog logs, log pipelines, log archives, log indexes, monitors, alerting,
+  mute, downtime, live debugger, dynamic instrumentation, log probes, symbol database, symdb,
+  CI Visibility, flaky test, test optimization, unblock PR, ddtrace, DD_API_KEY, DD_SITE.
 ---
 
 # Datadog Ninja
 
-**Jump Skill** — Master orchestrator that routes Datadog observability tasks to specialized skills from the official `DataDog/pup` repository and community Datadog skill collections.
+**Jump Skill** — Master orchestrator that routes Datadog observability tasks to the official skills shipped with the `DataDog/pup` CLI.
 
 ## Purpose
 
@@ -27,15 +26,15 @@ This skill acts as an intelligent router to the Datadog skills library. Instead 
 
 ## Prerequisites
 
-Nearly every skill in this catalog drives the **`pup` CLI** (the official Datadog CLI). Before executing a task:
+Every skill in this catalog drives the **`pup` CLI** (the official Datadog CLI). Before executing a task:
 
 1. Route to `dd-pup` if `pup` is not installed or not authenticated
 2. `pup` uses OAuth2 with token refresh — no long-lived key in the shell for interactive use
-3. Application-side code generation and CI tooling use `DD_API_KEY` / `DD_APP_KEY` instead
+3. Application-side code generation uses `DD_API_KEY` / `DD_APP_KEY` instead
 4. Datadog site matters (`datadoghq.com`, `datadoghq.eu`, `us3`, `us5`, `ap1`) — confirm `DD_SITE` before API calls
 
-> Read operations (searching logs, querying metrics, listing monitors) are safe to run directly.
-> Write operations (creating/muting monitors, declaring incidents, deleting pipelines) change
+> Read operations (searching logs, inspecting traces, listing monitors) are safe to run directly.
+> Write operations (creating or muting monitors, placing live probes, deleting pipelines) change
 > production state — confirm intent with the user before executing them.
 
 ## Skill Catalog
@@ -45,7 +44,7 @@ Nearly every skill in this catalog drives the **`pup` CLI** (the official Datado
 | Skill | Path | Use When |
 |-------|------|----------|
 | `dd-pup` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-pup/` | Install/authenticate the `pup` CLI, OAuth2 setup, token refresh, org and site selection |
-| `dd-docs` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-docs/` | Look up Datadog documentation via `docs.datadoghq.com/llms.txt` |
+| `dd-docs` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-docs/` | Look up Datadog documentation via `docs.datadoghq.com/llms.txt` and linked Markdown pages |
 | `dd-code-generation` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-code-generation/` | Generate application code using Datadog API clients (TypeScript, Python, Java, Go, Rust) instead of ad-hoc CLI calls |
 | `dd-file-issue` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-file-issue/` | File a bug or feature request against the `pup` CLI or its plugins |
 
@@ -53,22 +52,19 @@ Nearly every skill in this catalog drives the **`pup` CLI** (the official Datado
 
 | Skill | Path | Use When |
 |-------|------|----------|
-| `dd-apm` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-apm/` | Traces, services, dependencies, performance analysis (official) |
-| `datadog-apm` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-apm/` | Service maps, latency percentiles, continuous profiler, deeper APM API workflows |
+| `dd-apm` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-apm/` | Traces, services, dependencies, performance analysis |
 
 **APM Capabilities:**
 - Search and inspect distributed traces and spans
 - Map service dependencies and detect topology changes
 - Latency analysis (p50/p95/p99), error rates, throughput
 - Identify slow endpoints and downstream bottlenecks
-- Continuous profiling for CPU and memory hotspots
 
 ### Logs
 
 | Skill | Path | Use When |
 |-------|------|----------|
-| `dd-logs` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-logs/` | Log search, pipelines, archives, indexes, cost control (official) |
-| `datadog-logs` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-logs/` | Incident-time log investigation, error pattern analysis via `pup` |
+| `dd-logs` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-logs/` | Log search, pipelines, archives, indexes, cost control |
 
 **Log Capabilities:**
 - Search logs with Datadog query syntax and facets
@@ -76,24 +72,20 @@ Nearly every skill in this catalog drives the **`pup` CLI** (the official Datado
 - Configure indexes, exclusion filters, and retention for cost control
 - Set up and query log archives (S3/GCS/Azure) and rehydration
 
-### Metrics & SLOs
-
-| Skill | Path | Use When |
-|-------|------|----------|
-| `datadog-metrics` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-metrics/` | Query/submit metrics, custom metrics, SLIs, performance baselines, metric cardinality |
-
 ### Monitors & Alerting
 
 | Skill | Path | Use When |
 |-------|------|----------|
-| `dd-monitors` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-monitors/` | Create/update/mute monitors, alerting best practices (official) |
-| `datadog-monitors` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-monitors/` | Notification routing, deploy-window muting, SLO-based alerts |
+| `dd-monitors` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-monitors/` | Create, update, and mute monitors; alerting best practices |
 
-### Incidents
+### Live Debugging
 
 | Skill | Path | Use When |
 |-------|------|----------|
-| `datadog-incidents` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-incidents/` | Declare/manage/resolve incidents, timeline updates, responder coordination, postmortems |
+| `dd-symdb` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-symdb/` | Search a service's symbols to find probe-able methods |
+| `dd-debugger` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-debugger/` | Capture runtime argument/variable values in production with log probes — no redeploy |
+
+> `dd-symdb` almost always precedes `dd-debugger`: find the method, then probe it.
 
 ### CI Visibility & Test Optimization
 
@@ -101,65 +93,25 @@ Nearly every skill in this catalog drives the **`pup` CLI** (the official Datado
 |-------|------|----------|
 | `dd-unblock-pr` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-unblock-pr/` | A PR's CI is failing — attribute each failure as flaky, infra, or regression; report coverage |
 | `dd-triage-flaky-test` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-triage-flaky-test/` | Investigating one specific flaky test — history, failure pattern, fix vs quarantine vs escalate |
-| `datadog-ci-visibility` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-ci-visibility/` | Upload test results, track deployments, quality gates, pipeline monitoring via `datadog-ci` |
-
-### Live Debugging
-
-| Skill | Path | Use When |
-|-------|------|----------|
-| `dd-debugger` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-debugger/` | Capture runtime argument/variable values in production with log probes — no redeploy |
-| `dd-symdb` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/pup/skills/dd-symdb/` | Search a service's symbols to find probe-able methods before placing a probe |
-
-> `dd-symdb` almost always precedes `dd-debugger`: find the method, then probe it.
-
-### Synthetics
-
-| Skill | Path | Use When |
-|-------|------|----------|
-| `datadog-synthetics` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-synthetics/` | Synthetic API tests, browser tests, multi-step monitors via `datadog-ci` |
-
-### Security
-
-| Skill | Path | Use When |
-|-------|------|----------|
-| `datadog-security` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-security/` | Cloud SIEM security signals, CSPM findings, compliance posture, vulnerability triage |
-
-### AI / LLM Observability
-
-| Skill | Path | Use When |
-|-------|------|----------|
-| `datadog-ai-observability` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-ai-observability/` | Monitor LLM apps, trace agent chains, token usage, LLM evaluations |
-
-### Sales Engineering (non-technical)
-
-| Skill | Path | Use When |
-|-------|------|----------|
-| `datadog-demo` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-demo/` | Run a pre-built demo scenario of a Datadog investigation end-to-end |
-| `datadog-se-demo` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-se-demo/` | Structure an SE demo round or customer presentation |
-| `datadog-competitive` | `{{JUMP_SKILLS_DIR}}/repos/datadog-ninja/DataDogAdditions/skills/datadog-competitive/` | Datadog vs Splunk / New Relic / Dynatrace / Grafana / Elastic comparisons, battlecards |
-
-> These three are sales-oriented, not operational. Do not route engineering tasks to them.
 
 ## Routing Logic
 
 When a task arrives:
 
 1. **`pup` not installed or auth failing?** → `dd-pup` first, then the real skill
-2. **Slow service, latency, traces, spans, service map?** → `dd-apm` (add `datadog-apm` for profiling)
-3. **Searching logs, log pipelines, log cost/retention?** → `dd-logs` (`datadog-logs` for incident-time search)
-4. **Metrics, custom metrics, SLIs, baselines?** → `datadog-metrics`
-5. **Creating/muting alerts, notification routing?** → `dd-monitors` (`datadog-monitors` for SLO alerts)
-6. **Production incident, postmortem, responders?** → `datadog-incidents`
-7. **PR CI red, unclear if flaky?** → `dd-unblock-pr`
-8. **One known flaky test?** → `dd-triage-flaky-test`
-9. **Uploading test results, quality gates, deploy tracking?** → `datadog-ci-visibility`
-10. **"What value does this variable have in prod?"** → `dd-symdb` then `dd-debugger`
-11. **Uptime checks, browser tests, API monitoring?** → `datadog-synthetics`
-12. **Security signals, CSPM, compliance, vulns?** → `datadog-security`
-13. **LLM/agent tracing, token spend, evals?** → `datadog-ai-observability`
-14. **Instrumenting an app in code, API client?** → `dd-code-generation`
-15. **Datadog docs question?** → `dd-docs`
-16. **Demo, presentation, competitor comparison?** → `datadog-demo` / `datadog-se-demo` / `datadog-competitive`
+2. **Slow service, latency, traces, spans, service map?** → `dd-apm`
+3. **Searching logs, log pipelines, log cost/retention?** → `dd-logs`
+4. **Creating/muting alerts, alerting strategy?** → `dd-monitors`
+5. **"What value does this variable have in prod?"** → `dd-symdb` then `dd-debugger`
+6. **PR CI red, unclear if flaky?** → `dd-unblock-pr`
+7. **One known flaky test?** → `dd-triage-flaky-test`
+8. **Instrumenting an app in code, API client?** → `dd-code-generation`
+9. **Datadog product/feature question?** → `dd-docs`
+10. **`pup` itself is broken?** → `dd-file-issue`
+
+**Not covered by a dedicated skill.** Metrics queries, SLOs, incidents, synthetics, security signals,
+and dashboards have no dedicated skill in this catalog yet. For those, route to `dd-docs` for the
+correct API surface, then to `dd-code-generation` or plain `pup` commands to execute.
 
 ## Execution Pattern
 
@@ -178,23 +130,16 @@ When a task arrives:
 |------|----------|
 | Install / authenticate Datadog CLI | `dd-pup` |
 | Why is this endpoint slow? | `dd-apm` |
-| Profile CPU/memory in production | `datadog-apm` |
+| Which service is causing the errors? | `dd-apm` |
 | Search error logs for a service | `dd-logs` |
 | Cut log ingestion cost | `dd-logs` |
 | Build a log processing pipeline | `dd-logs` |
-| Query a custom metric | `datadog-metrics` |
-| Define an SLI / SLO | `datadog-metrics` |
 | Create an alert | `dd-monitors` |
-| Mute alerts during a deploy | `datadog-monitors` |
-| Declare an incident | `datadog-incidents` |
-| Write a postmortem | `datadog-incidents` |
+| Mute alerts during a deploy | `dd-monitors` |
+| What arguments does this function get in prod? | `dd-symdb` → `dd-debugger` |
+| Which methods can I probe on this service? | `dd-symdb` |
 | My PR's CI is red | `dd-unblock-pr` |
 | Is this test flaky? | `dd-triage-flaky-test` |
-| Add quality gates to CI | `datadog-ci-visibility` |
-| What arguments does this function get in prod? | `dd-symdb` → `dd-debugger` |
-| Add an uptime / browser check | `datadog-synthetics` |
-| Triage a security signal | `datadog-security` |
-| Trace an LLM agent chain | `datadog-ai-observability` |
 | Instrument my app with the Datadog SDK | `dd-code-generation` |
 | How does feature X work in Datadog? | `dd-docs` |
 | Report a `pup` bug | `dd-file-issue` |
@@ -207,27 +152,19 @@ Something is wrong in production
 Where does the symptom show up?
 ├── Requests slow / erroring
 │   ├── Which service? → dd-apm (service map, trace search)
-│   ├── Which line of code? → dd-apm (flame graph) → dd-debugger (live values)
-│   └── Resource-bound? → datadog-apm (continuous profiler)
+│   ├── Which endpoint / span? → dd-apm (trace detail)
+│   └── What were the actual runtime values? → dd-symdb → dd-debugger
 ├── Errors in the logs
-│   ├── Find them → dd-logs / datadog-logs
+│   ├── Find them → dd-logs (search, facets)
 │   └── Logs missing or malformed → dd-logs (pipelines, indexes)
-├── Host / infra symptom
-│   └── datadog-metrics (infra metrics, baselines)
 ├── Alert fired (or should have)
-│   ├── Tune / create → dd-monitors
-│   └── Routing / muting → datadog-monitors
-├── Users report it before you do
-│   └── datadog-synthetics (uptime & browser checks)
-├── It's an incident
-│   └── datadog-incidents (declare, coordinate, postmortem)
-└── It's suspicious, not just broken
-    └── datadog-security (signals, CSPM findings)
+│   └── dd-monitors (create, tune, mute)
+└── Need the API surface for something uncovered
+    └── dd-docs → dd-code-generation
 
 CI is broken (not production)
 ├── Whole PR pipeline red → dd-unblock-pr
-├── One test flapping → dd-triage-flaky-test
-└── Coverage / gates / uploads → datadog-ci-visibility
+└── One test flapping → dd-triage-flaky-test
 ```
 
 ## Common `pup` Commands
@@ -236,21 +173,25 @@ CI is broken (not production)
 pup auth login                          # OAuth2 login
 pup auth status                         # Verify authentication and org
 pup logs search 'service:api status:error' --from now-1h
-pup metrics query 'avg:system.cpu.user{*}' --from now-4h
+pup apm services list
 pup monitors list --tags team:platform
 pup monitors mute <monitor_id> --end <ts>
-pup apm services list
-pup incidents list --state active
 ```
 
 > Exact flags vary by `pup` version — route to `dd-pup` and confirm against `pup --help`
 > rather than assuming the syntax above.
 
+## Repositories
+
+| Repository | Skills | Description |
+|------------|--------|-------------|
+| [DataDog/pup](https://github.com/DataDog/pup) | 11 | Official Datadog CLI and its bundled agent skills (Apache-2.0) |
+
 ## Statistics
 
-- **Total Skills:** 20+ operational (23 including sales-engineering skills)
-- **Repositories:** `DataDog/pup` (official), `Kirneill/DataDogAdditions` (community)
-- **Source:** Official Datadog CLI skills + community Datadog skill collection
+- **Total Skills:** 11
+- **Repository:** `DataDog/pup` (official)
+- **License:** Apache-2.0
 
 ---
 

--- a/repos.md
+++ b/repos.md
@@ -66,6 +66,24 @@ https://github.com/firecrawl/skills
 
 ---
 
+## [datadog-ninja]
+
+Skills Datadog - observability, APM, logs, monitors, incidents, CI visibility e segurança.
+
+```repos
+https://github.com/DataDog/pup
+https://github.com/Kirneill/DataDogAdditions
+```
+
+| Repositório | Org | Descrição |
+|-------------|-----|-----------|
+| pup | DataDog | CLI oficial Datadog (`pup`) + skills oficiais: APM, logs, monitors, debugger, symdb, docs, triage de testes flaky |
+| DataDogAdditions | Kirneill | Skills portáveis da comunidade: métricas, incidents, synthetics, CI visibility, security, AI observability |
+
+**Skills incluídas:** dd-apm, dd-logs, dd-monitors, dd-debugger, dd-symdb, dd-docs, dd-pup, dd-code-generation, dd-file-issue, dd-triage-flaky-test, dd-unblock-pr, datadog-metrics, datadog-incidents, datadog-synthetics, datadog-ci-visibility, datadog-security, datadog-ai-observability.
+
+---
+
 ## [google-cloud-ninja]
 
 Skills Google Cloud Platform - infraestrutura, databases, networking, observability, segurança e Well-Architected Framework.

--- a/repos.md
+++ b/repos.md
@@ -52,6 +52,22 @@ https://github.com/github/awesome-copilot
 
 ---
 
+## [datadog-ninja]
+
+Skills Datadog oficiais - observabilidade via CLI `pup`: APM, logs, monitors, live debugger e CI/test optimization.
+
+```repos
+https://github.com/DataDog/pup
+```
+
+| Repositório | Org | Descrição |
+|-------------|-----|-----------|
+| pup | DataDog | CLI oficial Datadog (`pup`) + skills oficiais: APM, logs, monitors, live debugger, symbol database, docs e triage de CI/testes flaky |
+
+**Skills incluídas:** dd-pup (auth OAuth2), dd-docs, dd-code-generation, dd-file-issue, dd-apm, dd-logs, dd-monitors, dd-debugger, dd-symdb, dd-triage-flaky-test, dd-unblock-pr.
+
+---
+
 ## [firecrawl-ninja]
 
 Repositório oficial Firecrawl com skills para web scraping e research.
@@ -63,24 +79,6 @@ https://github.com/firecrawl/skills
 | Repositório | Org | Descrição |
 |-------------|-----|-----------|
 | skills | firecrawl | Skills core, build e workflows do Firecrawl CLI |
-
----
-
-## [datadog-ninja]
-
-Skills Datadog - observability, APM, logs, monitors, incidents, CI visibility e segurança.
-
-```repos
-https://github.com/DataDog/pup
-https://github.com/Kirneill/DataDogAdditions
-```
-
-| Repositório | Org | Descrição |
-|-------------|-----|-----------|
-| pup | DataDog | CLI oficial Datadog (`pup`) + skills oficiais: APM, logs, monitors, debugger, symdb, docs, triage de testes flaky |
-| DataDogAdditions | Kirneill | Skills portáveis da comunidade: métricas, incidents, synthetics, CI visibility, security, AI observability |
-
-**Skills incluídas:** dd-apm, dd-logs, dd-monitors, dd-debugger, dd-symdb, dd-docs, dd-pup, dd-code-generation, dd-file-issue, dd-triage-flaky-test, dd-unblock-pr, datadog-metrics, datadog-incidents, datadog-synthetics, datadog-ci-visibility, datadog-security, datadog-ai-observability.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **Datadog Ninja**, a Jump Skill that routes Datadog observability tasks to the 11 official agent skills bundled with the [`DataDog/pup`](https://github.com/DataDog/pup) CLI.

Datadog is a common companion to every cloud already covered here (AWS, Azure, GCP), but observability work currently has no Ninja to route to.

## Platform / Provider

**Datadog** — observability (APM, logs, monitors, live debugging, CI test optimization).

## Source Repositories

| Repository | Org | Skills | License |
|------------|-----|--------|---------|
| [DataDog/pup](https://github.com/DataDog/pup) | DataDog | 11 | Apache-2.0 |

Official vendor repository, per the "Prefer official repositories from the platform vendor" guidance.

**Note on a rejected source:** I initially also mapped [`Kirneill/DataDogAdditions`](https://github.com/Kirneill/DataDogAdditions) (12 further skills — metrics, incidents, synthetics, CI visibility, security, AI observability). I dropped it: that repository ships no `LICENSE`, `COPYING`, or `NOTICE` file, so its contents are all-rights-reserved by default and fail the checklist item *"All source repositories have compatible licenses."* Happy to revisit if it ever gets an explicit license.

## Skills Mapped — 11

| Category | Skills |
|----------|--------|
| **CLI & Foundation** (4) | `dd-pup` (OAuth2 auth), `dd-docs`, `dd-code-generation`, `dd-file-issue` |
| **APM & Tracing** (1) | `dd-apm` |
| **Logs** (1) | `dd-logs` |
| **Monitors** (1) | `dd-monitors` |
| **Live Debugging** (2) | `dd-symdb`, `dd-debugger` |
| **CI & Test Optimization** (2) | `dd-unblock-pr`, `dd-triage-flaky-test` |

## Special Considerations

- **`pup` is a hard prerequisite.** Every skill in the catalog drives the `pup` CLI, so the SKILL.md routes to `dd-pup` first whenever `pup` is missing or unauthenticated, and calls out `DD_SITE` (`datadoghq.com` / `.eu` / `us3` / `us5` / `ap1`) before any API call.
- **Write operations are gated.** Muting monitors, placing live probes, and deleting log pipelines change production state, so the execution pattern requires confirming with the user before running them. Read paths (log search, trace inspection, monitor listing) run directly.
- **Skill pairing.** `dd-symdb` almost always precedes `dd-debugger` — find the probe-able method, then probe it. The routing logic and decision tree encode this.
- **Honest coverage gaps.** Metrics, SLOs, incidents, synthetics, security signals, and dashboards have no dedicated skill in `DataDog/pup`. Rather than silently omitting them, the SKILL.md has an explicit "Not covered by a dedicated skill" section routing those to `dd-docs` → `dd-code-generation`.
- **README.md included.** CONTRIBUTING lists only `repos.md`, `ninjas.md`, and the SKILL.md for a new-Ninja PR. I also updated `README.md` so the `Ninjas-N` badge, the Available Ninjas list, and the structure tree stay consistent — glad to drop that file from the PR if you'd rather own the README yourself.
- **Alphabetical placement.** `datadog-ninja` is inserted before `firecrawl-ninja` in `ninjas.md`, `repos.md`, and the README, per the "alphabetical order preferred" note.

## Testing

```bash
./sync-repos.sh datadog-ninja     # 1 repo cloned, skills mapped
./install-ninjas.sh datadog-ninja # installed to 6 detected agents
```

Verified after install:
- All 11 `{{JUMP_SKILLS_DIR}}` catalog paths resolve to real `SKILL.md` files on disk
- Zero unsubstituted `{{JUMP_SKILLS_DIR}}` placeholders in any installed copy
- Zero broken paths across all 6 installed copies

## PR Checklist for New Ninjas

- [x] `repos.md` has new `[datadog-ninja]` section with repo URLs
- [x] `ninjas.md` has ninja in the `ninjas` block
- [x] `ninjas.md` has ninja in the description table
- [x] `ninjas/datadog-ninja/SKILL.md` exists with proper structure
- [x] SKILL.md uses `{{JUMP_SKILLS_DIR}}` placeholder in all paths
- [x] SKILL.md paths match actual skill locations in repos
- [x] Tested locally with `./sync-repos.sh datadog-ninja`
- [x] Tested locally with `./install-ninjas.sh datadog-ninja`
- [x] All source repositories have compatible licenses (Apache-2.0)

`repos/` and `.skills-map` are excluded — generated locally, git-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcc6hfvjiSJMPLrBorm8mX
